### PR TITLE
Added test

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -119,3 +119,15 @@ $ms = new-object System.IO.MemoryStream(, $bytes)
             subprocess.call(["wl-copy"], stdin=fp)
         im = ImageGrab.grabclipboard()
         assert_image_equal_tofile(im, image_path)
+
+    @pytest.mark.skipif(
+        (
+            sys.platform != "linux"
+            or not all(shutil.which(cmd) for cmd in ("wl-paste", "wl-copy"))
+        ),
+        reason="Linux with wl-clipboard only",
+    )
+    @pytest.mark.parametrize("arg", ("text", "--clear"))
+    def test_grabclipboard_wl_clipboard_errors(self, arg):
+        subprocess.call(["wl-copy", arg])
+        assert ImageGrab.grabclipboard() is None

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -163,11 +163,11 @@ def grabclipboard():
                 # wl-paste, when the clipboard is empty
                 b"Nothing is copied",
                 # wl-paste/debian xclip, when an image isn't available
-                b"not available",
+                b" not available",
                 # xclip, when an image isn't available
-                b"cannot convert",
+                b"cannot convert ",
                 # xclip, when the clipboard isn't initialized
-                b"There is no owner",
+                b"xclip: Error: There is no owner for the ",
             ]:
                 if err in silent_error:
                     return None

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -173,7 +173,7 @@ def grabclipboard():
                 # xclip, when the clipboard isn't initialized
                 b"xclip: Error: There is no owner for the ",
             ]:
-                if err in silent_error:
+                if silent_error in err:
                     return None
             msg = f"{args[0]} error"
             if err:

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -162,7 +162,11 @@ def grabclipboard():
             for silent_error in [
                 # wl-paste, when the clipboard is empty
                 b"Nothing is copied",
-                # wl-paste/debian xclip, when an image isn't available
+                # Ubuntu/Debian wl-paste, when the clipboard is empty
+                b"No selection",
+                # Ubuntu/Debian wl-paste, when an image isn't available
+                b"No suitable type of content copied",
+                # wl-paste or Ubuntu/Debian xclip, when an image isn't available
                 b" not available",
                 # xclip, when an image isn't available
                 b"cannot convert ",


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/7745

Adds a test for `ImageGrab.grabclipboard()` after `wl-copy --clear` and `wl-copy text` (as a dummy piece of text)

In doing so, I found two more possible errors - https://sources.debian.org/src/wl-clipboard/2.1.0-0.1/src/wl-paste.c/#L187 and https://sources.debian.org/src/wl-clipboard/2.1.0-0.1/src/wl-paste.c/#L205

I also realised that I'd written the condition to check the error the wrong way around.